### PR TITLE
Add capability to check for rogue users and keys

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,14 +7,13 @@ provisioner:
     verbose            : "vvvv"
     ansible_config     : "test/ansible.cfg"
     idempotency_test   : True
+    sudo               : True
 
 
 platforms:
     - name                      : travis
       provisioner               :
-        raw_arguments           : "-c local --ask-sudo-pass"
-        extra_vars              : 
-          xxxxx               : "hxx"
+        raw_arguments           : "-c local"
 
 suites:
   - name            : group

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,13 @@ python: "2.7"
 before_install:
   # Make sure everything's up to date.
   - sudo apt-get update -qq
-  - sudo apt-get install -qq python-apt python-pycurl git python-pip ruby ruby-dev bundler build-essential autoconf ruby-dep-selector
+  - sudo apt-get install -qq python-apt python-pycurl git python-pip ruby ruby-dev bundler build-essential autoconf
 
 install:
   - sudo pip install ansible
 
 
 script:
-    - cd test
     - ansible --version
     - bundle install
     - bundle exec kitchen test travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python: "2.7"
 before_install:
   # Make sure everything's up to date.
   - sudo apt-get update -qq
-  - sudo apt-get install -qq python-apt python-pycurl git python-pip ruby ruby-dev bundler build-essential autoconf
+  - sudo apt-get install -qq python-apt python-pycurl git python-pip ruby ruby-dev build-essential autoconf
+  - gem install bundler
 
 install:
   - sudo pip install ansible

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
-  gem 'berkshelf', '~> 3.0'
 
   gem 'test-kitchen'
   gem 'kitchen-vagrant'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,5 @@ default_temp_solution                       :
                                                - user: "x"
 
 usermanage_priv_key_suffix                  : ".ssh/id_rsa"
+
+usermanage_check_users                      : false

--- a/library/check_users.py
+++ b/library/check_users.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+
+import pwd
+import json
+from ansible.module_utils.basic import *
+
+NOOP_SHELL = [
+  "/usr/sbin/nologin",
+  '/bin/nologin',
+  '/bin/false'
+]
+
+class CheckUsers(object):
+  def __init__(self, module):
+    self.module = module
+    self.cusers = self.module.params["users_var"]
+
+  def main(self):
+    users = pwd.getpwall()
+    count = 0
+    for user in users:
+      name = user.pw_name
+      shell = user.pw_shell
+      uid = user.pw_uid
+      home_dir = user.pw_dir
+
+      if (uid > 999 and self.isValidShell(shell)):
+        if not self.isUserNameInDb(name):
+          self.module.fail_json(msg="User {} not defined by ansible".format(name))
+        else:
+          self.checkUsersKeys(user)
+      count = count + 1
+
+    result = {"changed": False, "msg": "Checked {} user accounts".format(count)}
+    self.module.exit_json(**result)
+
+  def isUserNameInDb(self, name):
+
+    for entry in self.cusers['users_db']:
+      if entry['name'] == name:
+        return True
+
+    return False
+
+  def isValidShell(self, shell):
+    if shell in NOOP_SHELL:
+      return False
+    return True
+
+  def checkUsersKeys(self, user):
+    usersKeys = None
+
+    for keys in self.cusers['key_db']:
+      if keys['user'] == user.pw_name:
+        usersKeys = keys
+        break
+
+    if usersKeys == None:
+      self.module.fail_json(msg="User {} has no ansible defined SSH keys".format(user.pw_name))
+
+    installed_keys = self.loadInstalledAuthorizedKeys(user)
+    configured_keys = []
+    for key in usersKeys['keys']:
+      configured_keys.append(key['key'])
+
+    for key in installed_keys:
+      if not key in configured_keys:
+        self.module.fail_json(msg="User {} has rogue ssh authorized keys".format(user.pw_name))
+
+
+  def loadInstalledAuthorizedKeys(self, user):
+    authorized_keys_file = os.path.join(user.pw_dir,'.ssh','authorized_keys')
+    if not os.path.isfile(authorized_keys_file):
+      self.module.fail_json(msg="Can't load authorized keys from {} for user {}".format(authorized_keys_file, user.pw_name))
+    with open(authorized_keys_file, 'r') as infile:
+      data = infile.read()
+    authorized_keys = data.splitlines()
+    return authorized_keys
+    
+
+def main():
+  module = AnsibleModule(
+      argument_spec=dict(
+          users_var=dict(default=None, required=True, type='dict')
+      ),
+      supports_check_mode=False
+  )
+  CheckUsers(module).main()
+
+if __name__ == '__main__':
+    main()

--- a/library/check_users.py
+++ b/library/check_users.py
@@ -14,6 +14,7 @@ class CheckUsers(object):
   def __init__(self, module):
     self.module = module
     self.cusers = self.module.params["users_var"]
+    self.fail_on_error = self.module["fail_on_error"]
 
   def main(self):
     users = pwd.getpwall()
@@ -26,7 +27,7 @@ class CheckUsers(object):
 
       if (uid > 999 and self.isValidShell(shell)):
         if not self.isUserNameInDb(name):
-          self.module.fail_json(msg="User {} not defined by ansible".format(name))
+          self.exitWithResult("User {} not defined by ansible".format(name))
         else:
           self.checkUsersKeys(user)
       count = count + 1
@@ -56,7 +57,7 @@ class CheckUsers(object):
         break
 
     if usersKeys == None:
-      self.module.fail_json(msg="User {} has no ansible defined SSH keys".format(user.pw_name))
+      self.exitWithResult("User {} has no ansible defined SSH keys".format(user.pw_name))
 
     installed_keys = self.loadInstalledAuthorizedKeys(user)
     configured_keys = []
@@ -65,23 +66,30 @@ class CheckUsers(object):
 
     for key in installed_keys:
       if not key in configured_keys:
-        self.module.fail_json(msg="User {} has rogue ssh authorized keys".format(user.pw_name))
+        self.exitWithResult("User {} has rogue ssh authorized keys".format(user.pw_name))
 
 
   def loadInstalledAuthorizedKeys(self, user):
     authorized_keys_file = os.path.join(user.pw_dir,'.ssh','authorized_keys')
     if not os.path.isfile(authorized_keys_file):
-      self.module.fail_json(msg="Can't load authorized keys from {} for user {}".format(authorized_keys_file, user.pw_name))
+      self.exitWithResult("Can't load authorized keys from {} for user {}".format(authorized_keys_file, user.pw_name))
     with open(authorized_keys_file, 'r') as infile:
       data = infile.read()
     authorized_keys = data.splitlines()
     return authorized_keys
+
+  def exitWithResult(self, message):
+    if self.fail_on_error:
+      self.module.fail_json(msg=message)
+    else:
+      self.module.exit_json(msg=message)
     
 
 def main():
   module = AnsibleModule(
       argument_spec=dict(
           users_var=dict(default=None, required=True, type='dict')
+          fail_on_error=dict(default=True, required=False, type='bool')
       ),
       supports_check_mode=False
   )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,6 @@
 
 - include: users.yml
 
+- check_users: users_var="{{cuser}}"
+  when: usermanage_check_users
+

--- a/test/application/advanced.yml
+++ b/test/application/advanced.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Advanced Mode (1)
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/group.yml
+++ b/test/application/group.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Group (1)
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/multi_source_files.yml
+++ b/test/application/multi_source_files.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Multi Sources files
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/simple.yml
+++ b/test/application/simple.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Simple Mode (1)
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/source_databag.yml
+++ b/test/application/source_databag.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Sources databag
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/source_files.yml
+++ b/test/application/source_files.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Sources files
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"

--- a/test/application/team.yml
+++ b/test/application/team.yml
@@ -1,6 +1,6 @@
 ---
 - name         : Team (1)
-  hosts        : all
+  hosts        : localhost
   gather_facts : no
   sudo         : True
   connection   : "{{ kitchen_connection | default('local') }}"


### PR DESCRIPTION
This pull requests adds the possibility to let ansible check for user accounts and ssh authorized keys which are not created by ansible. If there are user accounts which are not created by ansible or user accounts have authorized keys not created by this role, the playbook run will fail.
This feature is disabled by default not alter the default behavior of this role.
