### PR TITLE
User cuser.extra instead of cuser.user_db

### DIFF
--- a/library/usersdb.py
+++ b/library/usersdb.py
@@ -106,6 +106,7 @@ class UsersDB(object):
         user_server_keys = self._merge_key(user_db_key, user_server.get("keys", None), user_name, user_status)
         # In case of team user dict will not be defined so lets just define anyway
         user_server.update({"user": user_name})
+        user_server.update({"name": user_name})
 
         # Populate DBs
         user_server.pop("keys", None)  # Get rid of keys

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: users | Compile list of selected users extras (if interactive passed)
-  set_fact:
-    usermanage_selected_users_extra="{{ usermanage_selected_users_temp_list + cuser.extra | selectattr('name'| default('user'), 'equalto', item) | list }}"
-  with_items: usermanage_selected_users.split(',')
-  when: cuser.users_db is defined and usermanage_selected_users is defined
-  
 - name: users | Compile list of selected users (if interactive passed)
   set_fact:
     usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.users_db | selectattr('name'| default('user'), 'equalto', item) | list }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,7 +8,7 @@
   
 - name: users | Compile list of selected users (if interactive passed)
   set_fact:
-    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.users_db | selectattr('user'| default('user'), 'equalto', item) | list }}"
+    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.users_db | selectattr('name'| default('user'), 'equalto', item) | list }}"
   with_items: usermanage_selected_users.split(',')
   when: cuser.users_db is defined and usermanage_selected_users is defined
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -2,7 +2,7 @@
 
 - name: users | Compile list of selected users (if interactive passed)
   set_fact:
-    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.users_db | selectattr('name'| default('user'), 'equalto', item) | list }}"
+    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.extra | selectattr('name'| default('user'), 'equalto', item) | list }}"
   with_items: usermanage_selected_users.split(',')
   when: cuser.users_db is defined and usermanage_selected_users is defined
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,8 +1,14 @@
 ---
 
+- name: users | Compile list of selected users extras (if interactive passed)
+  set_fact:
+    usermanage_selected_users_extra="{{ usermanage_selected_users_temp_list + cuser.extra | selectattr('name'| default('user'), 'equalto', item) | list }}"
+  with_items: usermanage_selected_users.split(',')
+  when: cuser.users_db is defined and usermanage_selected_users is defined
+  
 - name: users | Compile list of selected users (if interactive passed)
   set_fact:
-    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.extra | selectattr('name'| default('user'), 'equalto', item) | list }}"
+    usermanage_selected_users_temp_list="{{ usermanage_selected_users_temp_list + cuser.users_db | selectattr('user'| default('user'), 'equalto', item) | list }}"
   with_items: usermanage_selected_users.split(',')
   when: cuser.users_db is defined and usermanage_selected_users is defined
 
@@ -80,3 +86,4 @@
   with_items: usermanage_users_privkey
   when: usermanage_users_privkey is defined
   no_log: True
+


### PR DESCRIPTION
This is to allow extra parameters like `openvpn` to be passed onwards in the process.

Also, we will need to create a new release after this is merged, since the latest release is really old and does not include `usermanage_select_user`
