### PR TITLE
tasks/users: fix syntax in failed_when

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -46,7 +46,7 @@
       - "{{ usermanage_keys_with_items }}"
       - keys
   register: keyrc
-  failed_when: "'failed' in keyrc and 'getpwnam' not in keyrc.msg"
+  failed_when: "keyrc is failed and 'getpwnam' not in keyrc.msg"
   when: cuser.key_db is defined
 
 - name: users | Manage private key for users


### PR DESCRIPTION
this message popped up during execution:
```
fatal: [host]: FAILED! => {"msg": "The conditional check ''failed' in keyrc and 'getpwnam' not in keyrc.msg' failed. The error was: error while evaluating conditional ('failed' in keyrc and 'getpwnam' not in keyrc.msg): Unable to look up a name or access an attribute in template string ({% if 'failed' in keyrc and 'getpwnam' not in keyrc.msg %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'StrictUndefined' is not iterable"}
```

kind regards